### PR TITLE
Enable installing/building on non-windows platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Node native module to encrypt/decrypt data. On Windows, it uses DPAPI
 ```typescript
 function protectData(
     userData: Uint8Array,
-    optionalEntropy: Uint8Array,
+    optionalEntropy: Uint8Array | null,
     scope: "CurrentUser" | "LocalMachine"
 ): Uint8Array;
 
 function unprotectData(
     encryptedData: Uint8Array,
-    optionalEntropy: Uint8Array,
+    optionalEntropy: Uint8Array | null,
     scope: "CurrentUser" | "LocalMachine"
 ): Uint8Array;
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const decrypted = dpapi.unprotectData(encrypted, null, "CurrentUser");
 ## FAQ:
 Q: Does this work on all platforms?
 
-A: Currently it just works on Windows
+A: Currently it just works on Window, but calling the protectData function from any other platform will result in an exception.
 
 ## Publish note
 This package originates from [bradhugh/node-dpapi](https://github.com/bradhugh/node-dpapi), but he [did not publish it to npm](https://github.com/bradhugh/node-dpapi/issues/1).  [I](https://github.com/daguej) have taken the liberty of publishing this package so it may be used as a dependency.

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,8 +7,12 @@
         "<!(node -e \"require('nan')\")",
         "include"
       ],
-      "libraries": [
-        "-lcrypt32.lib"
+      'conditions': [
+        ['OS == "win"', {
+          "libraries": [
+            "-lcrypt32.lib"
+          ]
+        }]
       ]
     }
   ]

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
 declare module "node-dpapi" {
     function protectData(
         userData: Uint8Array,
-        optionalEntropy: Uint8Array,
+        optionalEntropy: Uint8Array | null,
         scope: "CurrentUser" | "LocalMachine"
     ): Uint8Array;
 
     function unprotectData(
         encryptedData: Uint8Array,
-        optionalEntropy: Uint8Array,
+        optionalEntropy: Uint8Array | null,
         scope: "CurrentUser" | "LocalMachine"
     ): Uint8Array;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "win-dpapi",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node native module to encrypt/decrypt data. On Windows, it uses DPAPI",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
   ],
   "author": "Brad Hughes",
   "license": "MIT",
-  "os": [
-    "win32"
-  ],
   "dependencies": {
     "bindings": "^1.5.0",
     "nan": "^2.14.1"

--- a/src/node-dpapi.cpp
+++ b/src/node-dpapi.cpp
@@ -1,13 +1,16 @@
 #include <node.h>
 #include <nan.h>
-#include <Windows.h>
-#include <dpapi.h>
 #include <functional>
 
 v8::Local<v8::String> CreateUtf8String(v8::Isolate* isolate, char* strData)
 {
 	return v8::String::NewFromUtf8(isolate, strData, v8::NewStringType::kNormal).ToLocalChecked();
 }
+
+#ifdef _WIN32
+
+#include <Windows.h>
+#include <dpapi.h>
 
 void ProtectDataCommon(bool protect, Nan::NAN_METHOD_ARGS_TYPE info)
 {
@@ -106,6 +109,14 @@ void ProtectDataCommon(bool protect, Nan::NAN_METHOD_ARGS_TYPE info)
 
 	info.GetReturnValue().Set(returnBuffer);
 }
+
+#else
+
+void ProtectDataCommon(bool protect, Nan::NAN_METHOD_ARGS_TYPE info)
+{
+}
+
+#endif
 
 // public unsafe static byte[] Protect(byte[] userData, byte[] optionalEntropy, DataProtectionScope scope) 
 NAN_METHOD(protectData)


### PR DESCRIPTION
Hey, I was originally going to only make this PR on the other repo, but since you've got it published to npm and with extra commits I figured I should send it to this one.

Goal of this PR is to allow other platforms to install and rebuild this package again. With an empty implementation it should not show any build errors when running `npm rebuild`, the only thing is that callers have to be aware to only invoke the function on windows (obviously).